### PR TITLE
docs: trigger CI to verify protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,6 @@ python cli.py rename --path "/Photos" --date-prefix
 ## License
 
 MIT
+
+<!-- trigger CI -->
+


### PR DESCRIPTION
### Summary
Verifies branch protection and required CI by opening a trivial docs-only change.

### Changes
- Added a no-op comment to README to trigger CI.

### Test Plan
- CI runs `black` + `flake8` on PR.
- Merge is blocked until checks pass and branch is up to date.

### Checklist
- [x] Conventional commit title (`docs:` prefix)
- [x] No code behavior change
